### PR TITLE
Changes for Fedora 5

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,24 @@
 ---
 
-fcrepo_syn_version: 0.1.0
+# Version of Syn to install
+fcrepo_syn_version: 0.3.0
+
+# Where to store Syn
 fcrepo_syn_folder: /opt/syn
+
+# User for the tomcat container
 fcrepo_syn_user: tomcat8
+
+# Tomcat home
 fcrepo_syn_tomcat_home: /var/lib/tomcat8
+
+# Where to save the public key
 fcrepo_syn_default_public_key_path: "{{ fcrepo_syn_tomcat_home }}/conf/public.key"
+
+# The HTTP header to put the roles on
+fcrepo_syn_auth_header:
+
+# Configured sites
 fcrepo_syn_sites: []
 # - url:
 #   algorithm:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -18,29 +18,3 @@
     path: "{{ fcrepo_syn_tomcat_home }}/conf/context.xml"
     line: "<Valve className=\"ca.islandora.syn.valve.SynValve\" pathname=\"{{ fcrepo_syn_tomcat_home }}/conf/syn-settings.xml\" />"
     insertbefore: "</Context>"
-
-- name: Modify web.xml
-  blockinfile:
-    path: "{{ fcrepo_syn_tomcat_home }}/webapps/fcrepo/WEB-INF/web.xml"
-    insertbefore: "^</web-app>$"
-    marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
-    block: |
-      <security-constraint>
-        <web-resource-collection>
-          <web-resource-name>Fedora4</web-resource-name>
-          <url-pattern>/*</url-pattern>
-        </web-resource-collection>
-        <auth-constraint>
-          <role-name>*</role-name>
-        </auth-constraint>
-        <user-data-constraint>
-          <transport-guarantee>NONE</transport-guarantee>
-        </user-data-constraint>
-      </security-constraint>
-      <security-role>
-        <role-name>islandora</role-name>
-      </security-role>
-      <login-config>
-        <auth-method>BASIC</auth-method>
-        <realm-name>fcrepo</realm-name>
-      </login-config>

--- a/templates/syn-settings.xml
+++ b/templates/syn-settings.xml
@@ -1,5 +1,5 @@
 <!-- This file is managed with Ansible -->
-<config version='1'>
+<config version='1' header='{{ fcrepo_syn_auth_header }}'>
 {% for site in fcrepo_syn_sites %}
     <site
     {%- if site.url is defined %}


### PR DESCRIPTION
Related to https://github.com/Islandora-CLAW/CLAW/issues/966

This PR updates the ansible role to include the new `header` argument to the Syn configuration file. It also removes the changes to the `web.xml` as Fedora 5.0.0 has this by default.

Instructions for testing this are on https://github.com/Islandora-Devops/claw-playbook/pull/86

@Islandora-Devops/committers 