### PR TITLE
Update to run on Tomcat 9 and Ubuntu 20.04 Focal64

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ fcrepo_syn_tokens: []
 
 ## Dependencies
 
-* Islandora-Devops.tomcat8
-     * [Github](https://github.com/Islandora-Devops/ansible-role-tomcat8)
-     * [Galaxy](https://galaxy.ansible.com/Islandora-Devops/tomcat8/)
+* Islandora-Devops.tomcat9
+     * [Github](https://github.com/Islandora-Devops/ansible-role-tomcat9)
+     * [Galaxy](https://galaxy.ansible.com/Islandora-Devops/tomcat9/)
   
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,10 +7,10 @@ fcrepo_syn_version: 1.1.0
 fcrepo_syn_folder: /opt/syn
 
 # User for the tomcat container
-fcrepo_syn_user: tomcat8
+fcrepo_syn_user: tomcat
 
 # Tomcat home
-fcrepo_syn_tomcat_home: /var/lib/tomcat8
+fcrepo_syn_tomcat_home: /var/lib/tomcat9
 
 # Where to save the public key
 fcrepo_syn_default_public_key_path: "{{ fcrepo_syn_tomcat_home }}/conf/public.key"


### PR DESCRIPTION
**GitHub Issue**: [Update playbook to Ubuntu 20.04 Focal64](https://github.com/Islandora/documentation/issues/1792)

# What does this Pull Request do?

Update to run on Tomcat 9 and Ubuntu 20.04 Focal64.

# What's new?

Update paths to match Tomcat 9.

# How should this be tested?

Test as part of a full Focal64 playbook build. Token authentication should work as normal.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
